### PR TITLE
Remove duplicate AuthenticationManager definition

### DIFF
--- a/src/main/java/io/homo_efficio/springsecuritypractice/SimpleUsernamePasswordAuthFilter.java
+++ b/src/main/java/io/homo_efficio/springsecuritypractice/SimpleUsernamePasswordAuthFilter.java
@@ -22,14 +22,16 @@ import java.io.IOException;
 @Slf4j
 public class SimpleUsernamePasswordAuthFilter extends UsernamePasswordAuthenticationFilter {
 
-    private final AuthenticationManager authenticationManager;
+    public SimpleUsernamePasswordAuthFilter(AuthenticationManager manager) {
+        setAuthenticationManager(manager);
+    }
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
         String username = obtainUsername(request);
         String password = obtainPassword(request);
         log.info("username: {}, password: {}", username, password);
-        return authenticationManager.authenticate(
+        return getAuthenticationManager().authenticate(
                 new UsernamePasswordAuthenticationToken(username, password)
         );
     }


### PR DESCRIPTION
Previously SimpleUsernamePasswordAuthFilter had a separate reference to an
AuthenticationManager from the one defined in
UsernamePasswordAuthenticationFilter. This means there was an unused
variable in UsernamePasswordAuthenticationFilter. It also meant that
SimpleUsernamePasswordAuthFilter.setAuthenticationManager was setting an
AuthenticationManager that wasn't used for authenticating.

This removes the unnecessary AuthenticationMnaager and instead sets the
UsernamePasswordAuthenticationFilter instance.